### PR TITLE
fix: record unstated topic

### DIFF
--- a/config/autoware_bag_recorder.param.yaml
+++ b/config/autoware_bag_recorder.param.yaml
@@ -43,7 +43,8 @@
         - /localization/pose_estimator/transform_probability
         - /localization/pose_twist_fusion_filter/estimated_yaw_bias
         - /localization/pose_twist_fusion_filter/kinematic_state
-        - /localization/pose_twist_fusion_filter/pose
+        - /localization/pose_twist_fusion_filter/pose$
+        - /localization/pose_twist_fusion_filter/pose_instability_detector/debug/diff_pose
         - /localization/pose_twist_fusion_filter/pose_with_covariance_without_yawbias
         - /localization/pose_twist_fusion_filter/pose_without_yawbias
         - /localization/pose_twist_fusion_filter/twist


### PR DESCRIPTION
It was recording all topic started with `/localization/pose_twist_fusion_filter/pose`.